### PR TITLE
init: Don't start sysinit before filesystem is mounted

### DIFF
--- a/prebuilt/common/etc/init.eos.rc
+++ b/prebuilt/common/etc/init.eos.rc
@@ -7,6 +7,7 @@ on init
     export ANDROID_CACHE /cache
     export TERMINFO /system/etc/terminfo
 
+on post-fs-data
     # Run sysinit
     start sysinit
 


### PR DESCRIPTION
On my device sysinit starts before system is mounted. Start sysinit on post-sf-data to correct this.
